### PR TITLE
select only the first line of output

### DIFF
--- a/image-install-calamares.sh
+++ b/image-install-calamares.sh
@@ -275,7 +275,7 @@ _partition_format_mount() {
    done
    ##### Determine data device size in MiB and partition ###
    printf "\n${CYAN}Partitioning, & formatting storage device...${NC}\n"
-   DEVICESIZE=$(fdisk -l | grep "Disk $DEVICENAME" | awk '{print $5}')
+   DEVICESIZE=$(fdisk -l | grep "Disk $DEVICENAME" | head -n 1 | awk '{print $5}')
    ((DEVICESIZE=$DEVICESIZE/1048576))
    ((DEVICESIZE=$DEVICESIZE-1))  # for some reason, necessary for USB thumb drives
    printf "\n${CYAN}Partitioning storage device $DEVICENAME...${NC}\n"


### PR DESCRIPTION
ran into an issue when on pbp when i have devices like: mmcblk2
mmcblk2boot0
mmcblk2boot1
in this case you only want the size from the first line.